### PR TITLE
Show caption only if there is image title or description

### DIFF
--- a/components/carousel/default.htm
+++ b/components/carousel/default.htm
@@ -12,6 +12,9 @@
     {% for i, image in __SELF__.carousel.images %}
     <div class="item{% if loop.first %} active{% endif %}">
       <img src="{{ image.path }}" alt="{{ image.title }}">
+
+      {# Show caption only if there is image title or description #}
+      {% if image.title || image.description %}
       <div class="carousel-caption">
 
         {% if image.title %}<h3>{{ image.title }}</h3>{% endif %}
@@ -19,6 +22,8 @@
         {% if image.description %}<p>{{ image.description }}</p>{% endif %}
 
       </div>
+      {% endif %}
+
     </div>
     {% endfor %}
   </div>

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -7,3 +7,5 @@
 1.0.4: Bug fix for multiple carousel components in same page.
 1.0.5:
   - !!! Developer can now chose display carousels section in navigation menu or settings page.
+1.0.6:
+  - Show caption only if there is image title or description


### PR DESCRIPTION
Show the caption of the carousel only if there is at least the image title or description. This prevents the display of the caption background if there is no text to show. 